### PR TITLE
fix: renamed telegram_channel_id to Config.telegram_chat_id

### DIFF
--- a/subito_scanner.py
+++ b/subito_scanner.py
@@ -187,7 +187,7 @@ def main():
                         send_slack_message(item_title, item_price, item_url, item_image)
 
                     # Send Telegram notifications if configured
-                    if Config.telegram_bot_token and telegram_channel_id:
+                    if Config.telegram_bot_token and Config.telegram_chat_id:
                         send_telegram_message(item_title, item_price, item_url, item_image)
 
                     # Mark item as analyzed and save it


### PR DESCRIPTION
Fix NameError:

> Traceback (most recent call last):
  File "/app/subito_[scanner.py](https://scanner.py/)", line 198, in <module>
    main()
  File "/app/subito_[scanner.py](https://scanner.py/)", line 190, in main
    if Config.telegram_bot_token and telegram_channel_id:
NameError: name 'telegram_channel_id' is not defined